### PR TITLE
ZenMode : Update defaults for CTSVerifier

### DIFF
--- a/core/res/res/xml/default_zen_mode_config.xml
+++ b/core/res/res/xml/default_zen_mode_config.xml
@@ -19,6 +19,6 @@
 
 <!-- Default configuration for zen mode.  See android.service.notification.ZenModeConfig. -->
 <zen version="1">
-    <allow calls="false" messages="false" />
+    <allow calls="false" messages="true" from="2" />
     <sleep startHour="22" startMin="0" endHour="7" endMin="0" />
 </zen>


### PR DESCRIPTION
The default settings for Priority Notifications should
allow messages to be priority interruptions and Calls/Messages
from Starred contacts only in order to pass CTS-Verifier.

CYNGNOS-1364

Change-Id: Ie3046bd3d32e001aa639648dff2e8a6caafc91bc
